### PR TITLE
Give SceneMachine responsibility over switching scenes.

### DIFF
--- a/src/events.py
+++ b/src/events.py
@@ -40,25 +40,20 @@ class InputEvent(object):
         self.pressed = pressed
 
     def __str__(self) -> str:
-        return '%s, key=%s, mouse=%s, pressed=%s' % (self.event, self.key, self.mouse, self.pressed)
-
-
-class Listener(object):
-
-    def notify(self, event: Event) -> None:
-        raise NotImplementedError("Subclasses must implement notify()")
+        return '%s, key=%s, mouse=%s, pressed=%s' % (
+            self.event, self.key, self.mouse, self.pressed)
 
 
 class EventManager(object):
     def __init__(self) -> None:
         self.listeners: WeakKeyDictionary = WeakKeyDictionary()
 
-    def register(self, l: Listener) -> None:
+    def register(self, l: 'EventListener') -> None:
         self.listeners[l] = 1
         logging.debug('registered listener {0} {1}'.format(
             len(self.listeners), l))
 
-    def unregister(self, l: Listener) -> None:
+    def unregister(self, l: 'EventListener') -> None:
         if l in self.listeners.keys():
             logging.debug('unregistered listener {0} {1}'.format(
                 len(self.listeners), l))
@@ -73,14 +68,14 @@ class EventManager(object):
             l.notify(event)
 
 
-class EventListener(Listener):
+class EventListener(object):
 
     def __init__(self, event_manager: EventManager) -> None:
         event_manager.register(self)
         self.event_manager = event_manager
 
     def notify(self, event: Event) -> None:
-        pass
+        raise NotImplementedError('Subclesses must implement this method.')
 
     def unregister(self) -> None:
         self.event_manager.unregister(self)

--- a/src/game.py
+++ b/src/game.py
@@ -5,10 +5,7 @@ from events import EventListener
 from events import EventManager
 from controller import Controller
 from keyboard import Keyboard
-from launch_controller import LaunchController
-from settings_controller import SettingsController
 from scene_machine import SceneMachine
-from world import World
 import constants
 import pygame
 import sys

--- a/src/game.py
+++ b/src/game.py
@@ -41,13 +41,10 @@ class Game(EventListener):
 
         self.keyboard = Keyboard(self.event_manager)
 
-        self.scene_machine = SceneMachine()
         self.world = World()
 
-        # Change controller to change what is shown on the screen.
-        self.controller = None
-        self.prev_controller = None
-        self._new_game()
+        self.scene_machine = SceneMachine(self.event_manager, self.world,
+                                          self.screen)
 
     def notify(self, event: Event) -> None:
         if event == Event.QUIT:
@@ -57,10 +54,6 @@ class Game(EventListener):
             # limit the redraw speed to 30 frames per second
 
             self.clock.tick(constants.FRAMES_PER_SECOND)
-        elif event == Event.SETTINGS:
-            self._toggle_settings()
-        elif event == Event.NEW_SCENE:
-            self._set_next_scene()
 
     def run(self) -> None:
         while True:
@@ -70,23 +63,3 @@ class Game(EventListener):
         pygame.mixer.pre_init(44100, -16, 4, 2048)
         pygame.init()
         pygame.font.init()
-
-    def _toggle_settings(self) -> None:
-        if isinstance(self.controller, SettingsController):
-            self._remove_controller(self.controller)
-            self.controller = self.prev_controller
-        else:
-            self.prev_controller = self.controller
-            self.controller = SettingsController(self.event_manager, self.screen)
-
-    def _new_game(self) -> None:
-        self.controller = LaunchController(self.event_manager, self.screen)
-
-    def _set_next_scene(self) -> None:
-        self._remove_controller(self.controller)
-        self.controller = self.scene_machine.build_scene(
-            self.world, self.event_manager, self.screen)
-
-    def _remove_controller(self, controller: Controller) -> None:
-        self.controller.unregister()
-        del controller

--- a/src/game.py
+++ b/src/game.py
@@ -24,7 +24,7 @@ class GameState(Enum):
 # TODO(mick): create player state
 
 class Game(EventListener):
-    """Loads scenes, stores world, and handles framerate and quit event."""
+    """Stores sceneMachine and keyboard, andles framerate and quit event."""
     keyboard: Keyboard = None
     event_manager: EventManager = None
     controller: Controller = None
@@ -36,15 +36,10 @@ class Game(EventListener):
         self._initialize_pygame()
 
         self.clock: pygame.Clock = pygame.time.Clock()
-        self.screen: pygame.Surface = pygame.display.set_mode(
-            constants.SCREEN_SIZE)
 
         self.keyboard = Keyboard(self.event_manager)
 
-        self.world = World()
-
-        self.scene_machine = SceneMachine(self.event_manager, self.world,
-                                          self.screen)
+        self.scene_machine = SceneMachine(self.event_manager)
 
     def notify(self, event: Event) -> None:
         if event == Event.QUIT:

--- a/src/game.py
+++ b/src/game.py
@@ -21,7 +21,7 @@ class GameState(Enum):
 # TODO(mick): create player state
 
 class Game(EventListener):
-    """Stores sceneMachine and keyboard, andles framerate and quit event."""
+    """Stores sceneMachine and keyboard, handles framerate and quit event."""
     keyboard: Keyboard = None
     event_manager: EventManager = None
     controller: Controller = None

--- a/src/scene_machine.py
+++ b/src/scene_machine.py
@@ -1,5 +1,6 @@
 import pygame
 
+import constants
 from controller import Controller
 from launch_controller import LaunchController
 from settings_controller import SettingsController
@@ -12,11 +13,11 @@ from pygame import Surface
 class SceneMachine(EventListener):
     """Handles transitions between scenes."""
 
-    def __init__(self, event_manager: EventManager, world: World,
-                 screen: pygame.Surface) -> None:
+    def __init__(self, event_manager: EventManager) -> None:
         super().__init__(event_manager)
-        self.world = world
-        self.screen = screen
+        self.world = World()
+        self.screen: pygame.Surface = pygame.display.set_mode(
+            constants.SCREEN_SIZE)
 
         self.controller = LaunchController(self.event_manager, self.screen)
         self.prev_controller = None
@@ -29,7 +30,7 @@ class SceneMachine(EventListener):
 
     def _set_next_scene(self) -> None:
         self._remove_controller(self.controller)
-        self.controller = self.build_scene(
+        self.controller = self._build_scene(
             self.world, self.event_manager, self.screen)
 
     def _remove_controller(self, controller: Controller) -> None:
@@ -45,7 +46,7 @@ class SceneMachine(EventListener):
             self.controller = SettingsController(self.event_manager,
                                                  self.screen)
 
-    def build_scene(
+    def _build_scene(
             self,
             world: World,
             event_manager: EventManager,

--- a/src/scene_machine.py
+++ b/src/scene_machine.py
@@ -15,12 +15,12 @@ class SceneMachine(EventListener):
 
     def __init__(self, event_manager: EventManager) -> None:
         super().__init__(event_manager)
-        self.world = World()
-        self.screen: pygame.Surface = pygame.display.set_mode(
+        self._world = World()
+        self._screen: pygame.Surface = pygame.display.set_mode(
             constants.SCREEN_SIZE)
 
-        self.controller = LaunchController(self.event_manager, self.screen)
-        self.prev_controller = None
+        self._controller = LaunchController(self.event_manager, self._screen)
+        self._prev_controller = None
 
     def notify(self, event: Event) -> None:
         if event == Event.SETTINGS:
@@ -29,22 +29,22 @@ class SceneMachine(EventListener):
             self._set_next_scene()
 
     def _set_next_scene(self) -> None:
-        self._remove_controller(self.controller)
-        self.controller = self._build_scene(
-            self.world, self.event_manager, self.screen)
+        self._remove_controller(self._controller)
+        self._controller = self._build_scene(
+            self._world, self.event_manager, self._screen)
 
     def _remove_controller(self, controller: Controller) -> None:
-        self.controller.unregister()
+        self._controller.unregister()
         del controller
 
     def _toggle_settings(self) -> None:
-        if isinstance(self.controller, SettingsController):
-            self._remove_controller(self.controller)
-            self.controller = self.prev_controller
+        if isinstance(self._controller, SettingsController):
+            self._remove_controller(self._controller)
+            self._controller = self._prev_controller
         else:
-            self.prev_controller = self.controller
-            self.controller = SettingsController(self.event_manager,
-                                                 self.screen)
+            self._prev_controller = self._controller
+            self._controller = SettingsController(self.event_manager,
+                                                  self._screen)
 
     def _build_scene(
             self,

--- a/src/scene_machine.py
+++ b/src/scene_machine.py
@@ -1,13 +1,49 @@
+import pygame
+
+from controller import Controller
+from launch_controller import LaunchController
+from settings_controller import SettingsController
 from world import World
 from scene_controller import SceneController
-from events import EventManager
+from events import EventManager, EventListener, Event
 from pygame import Surface
 
 
-class SceneMachine(object):
+class SceneMachine(EventListener):
+    """Handles transitions between scenes."""
 
-    def __init__(self) -> None:
-        pass
+    def __init__(self, event_manager: EventManager, world: World,
+                 screen: pygame.Surface) -> None:
+        super().__init__(event_manager)
+        self.world = world
+        self.screen = screen
+
+        self.controller = LaunchController(self.event_manager, self.screen)
+        self.prev_controller = None
+
+    def notify(self, event: Event) -> None:
+        if event == Event.SETTINGS:
+            self._toggle_settings()
+        elif event == Event.NEW_SCENE:
+            self._set_next_scene()
+
+    def _set_next_scene(self) -> None:
+        self._remove_controller(self.controller)
+        self.controller = self.build_scene(
+            self.world, self.event_manager, self.screen)
+
+    def _remove_controller(self, controller: Controller) -> None:
+        self.controller.unregister()
+        del controller
+
+    def _toggle_settings(self) -> None:
+        if isinstance(self.controller, SettingsController):
+            self._remove_controller(self.controller)
+            self.controller = self.prev_controller
+        else:
+            self.prev_controller = self.controller
+            self.controller = SettingsController(self.event_manager,
+                                                 self.screen)
 
     def build_scene(
             self,


### PR DESCRIPTION
Specifically, World no longer changes scenes or stores the controller. The goal of this change was to align the code better with Single Responsibility Principle.