### PR TITLE
Mods in character inventory can now affect attributes and states.

### DIFF
--- a/src/controllers/decision_scene_controller.py
+++ b/src/controllers/decision_scene_controller.py
@@ -34,6 +34,7 @@ class DecisionSceneController(Controller):
                 for effect in resolution.effects:
                     effect.execute(self.world)
 
+                self.deactivate()
                 if IsDead().check(self.world.player):
                     post_scene_change(game_over(self.world))
                     return

--- a/src/controllers/launch_controller.py
+++ b/src/controllers/launch_controller.py
@@ -21,4 +21,5 @@ class LaunchController(Controller):
         if event == Event.TICK:
             self.view.render()
         elif isinstance(event, InputEvent) and event.key == 's':
+            self.deactivate()
             post_scene_change(self._start_scene)

--- a/src/models/character_base.py
+++ b/src/models/character_base.py
@@ -1,11 +1,29 @@
 """Basic class for player and enemies."""
-from models.states import Stateful, Attribute
+from models.inventory import BasicInventory
+from models.states import Attribute, AttributeType, Stateful, BasicStatus, State
 
 
 class Character(Stateful):
+    """Stateful object with states and attributes affected by mods."""
 
     def __init__(self, health: int) -> None:
         super().__init__()
-        self.set_attribute(Attribute.MAX_HEALTH, health)
-        self.set_attribute(Attribute.HEALTH, health)
-        self.set_attribute_bounds(Attribute.HEALTH, 0, Attribute.MAX_HEALTH)
+        status = BasicStatus()
+        status.set_attribute(Attribute.MAX_HEALTH, health)
+        status.set_attribute(Attribute.HEALTH, health)
+        status.set_attribute_bounds(Attribute.HEALTH, 0, Attribute.MAX_HEALTH)
+
+        self._base_status = status
+        self.inventory = BasicInventory()
+
+    def has_state(self, state: State) -> bool:
+        return (self._base_status.has_state(state)
+                or self.inventory.grants_state(state))
+
+    def increment_attribute(self, attribute: AttributeType, delta: int) -> None:
+        self._base_status.increment_attribute(attribute, delta)
+
+    def get_attribute(self, attribute: AttributeType) -> int:
+        modifier = self.inventory.total_modifier(attribute)
+        value = self._base_status.get_attribute(attribute) + modifier
+        return self._base_status.value_in_bounds(value, attribute)

--- a/src/models/character_base_test.py
+++ b/src/models/character_base_test.py
@@ -2,7 +2,7 @@ from models.character_base import Character
 from unittest import TestCase
 
 from models.conditions import IsDead
-from models.mod_examples import HelmOfBeingOnFire
+from models.mod_examples import HelmOfBeingOnFire, HullPlating
 from models.states import Attribute, State
 
 
@@ -25,3 +25,12 @@ class CharacterTest(TestCase):
         assert not char.has_state(State.ON_FIRE)
         char.inventory.store(HelmOfBeingOnFire())
         assert char.has_state(State.ON_FIRE)
+
+    def test_mods_affect_max_attribute(self):
+        health = 10
+        char = Character(health)
+        max_health = char.get_attribute(Attribute.MAX_HEALTH)
+        bonus = 5
+        char.inventory.store(HullPlating(bonus))
+
+        assert char.get_attribute(Attribute.MAX_HEALTH) == max_health + bonus

--- a/src/models/character_base_test.py
+++ b/src/models/character_base_test.py
@@ -2,7 +2,8 @@ from models.character_base import Character
 from unittest import TestCase
 
 from models.conditions import IsDead
-from models.states import Attribute
+from models.mod_examples import HelmOfBeingOnFire
+from models.states import Attribute, State
 
 
 class CharacterTest(TestCase):
@@ -10,10 +11,17 @@ class CharacterTest(TestCase):
     def test_character_has_attributes(self):
         health = 10
         char = Character(health)
-        assert char.get_attribute(Attribute.HEALTH)
+        assert char.get_attribute(Attribute.HEALTH) == health
 
     def test_kill_character(self):
         health = 10
         char = Character(health)
         char.increment_attribute(Attribute.HEALTH, -health)
         self.assertTrue(IsDead().check(char))
+
+    def test_character_state_change(self):
+        char = Character(health=10)
+
+        assert not char.has_state(State.ON_FIRE)
+        char.inventory.store(HelmOfBeingOnFire())
+        assert char.has_state(State.ON_FIRE)

--- a/src/models/conditions.py
+++ b/src/models/conditions.py
@@ -1,7 +1,7 @@
 import abc
 from typing import Any
 
-from models.states import Stateful, State, Attribute
+from models.states import State, Attribute, Stateful
 
 
 class Condition(metaclass=abc.ABCMeta):

--- a/src/models/conditions_test.py
+++ b/src/models/conditions_test.py
@@ -1,9 +1,9 @@
 from models.conditions import HasState, IsDead
-from models.states import Stateful, State, Attribute
+from models.states import BasicStatus, State, Attribute
 
 
 def test_condition_and():
-    stateful = Stateful()
+    stateful = BasicStatus()
 
     cond = HasState(State.ON_FIRE) & IsDead()
     assert not cond.check(stateful)
@@ -14,7 +14,7 @@ def test_condition_and():
 
 
 def test_condition_or():
-    stateful = Stateful()
+    stateful = BasicStatus()
 
     cond = HasState(State.ON_FIRE) | IsDead()
     assert cond.check(stateful)
@@ -26,7 +26,7 @@ def test_condition_or():
 
 
 def test_condition_not():
-    stateful = Stateful()
+    stateful = BasicStatus()
     cond = HasState(State.ON_FIRE)
 
     assert ~cond.check(stateful)
@@ -36,7 +36,7 @@ def test_condition_not():
 
 
 def test_alive_to_dead():
-    stateful = Stateful()
+    stateful = BasicStatus()
 
     assert IsDead().check(stateful)
     stateful.set_attribute(Attribute.HEALTH, 3)

--- a/src/models/effects.py
+++ b/src/models/effects.py
@@ -1,5 +1,5 @@
 from scenes.scenes_base import Effect
-from models.states import Stateful, AttributeType
+from models.states import AttributeType, Stateful
 from models.world import World
 
 

--- a/src/models/states.py
+++ b/src/models/states.py
@@ -1,4 +1,5 @@
 """Abstract implementation of states and conditions."""
+from abc import ABCMeta, abstractmethod
 from collections import defaultdict
 from enum import Enum
 from typing import Union, Callable, Dict, Tuple
@@ -38,7 +39,26 @@ _BoundFun = Callable[['Stateful'], int]
 _BoundType = Union[int, Attribute, _BoundFun]
 
 
-class Stateful(object):
+class Stateful(object, metaclass=ABCMeta):
+    @abstractmethod
+    def has_state(self, state: State) -> bool:
+        """Whether object has a given state.
+
+        If not otherwise set, default is False."""
+
+    @abstractmethod
+    def get_attribute(self, attribute: AttributeType) -> int:
+        """Value associated with an Attribute.
+
+        If not otherwise set, default value is 0."""
+
+    @abstractmethod
+    def increment_attribute(self, attribute: AttributeType, delta: int) -> None:
+        """Increment an attribute by a fixed amount."""
+
+
+class BasicStatus(Stateful):
+    """A Stateful object implemented using simple dictionaries."""
 
     def __init__(self) -> None:
         self._states: defaultdict = defaultdict(lambda: False)
@@ -85,7 +105,7 @@ class Stateful(object):
 
         return int_fun
 
-    def _value_in_bounds(self, value: int, attribute: AttributeType) -> int:
+    def value_in_bounds(self, value: int, attribute: AttributeType) -> int:
         if attribute in self._attribute_bounds:
             lower, upper = self._attribute_bounds[attribute]
             l_val, u_val = lower(self), upper(self)
@@ -96,11 +116,9 @@ class Stateful(object):
 
     def increment_attribute(self, attribute: AttributeType, delta: int) -> None:
         new_val = self._attributes[attribute] + delta
-        new_val = self._value_in_bounds(new_val, attribute)
+        new_val = self.value_in_bounds(new_val, attribute)
         self._attributes[attribute] = new_val
 
     def set_attribute(self, attribute: AttributeType, value: int) -> None:
-        value = self._value_in_bounds(value, attribute)
+        value = self.value_in_bounds(value, attribute)
         self._attributes[attribute] = value
-
-

--- a/src/models/states.py
+++ b/src/models/states.py
@@ -85,20 +85,22 @@ class Stateful(object):
 
         return int_fun
 
-    def _set_attribute_in_bounds(self, attribute: AttributeType) -> None:
+    def _value_in_bounds(self, value: int, attribute: AttributeType) -> int:
         if attribute in self._attribute_bounds:
-            value = self._attributes[attribute]
             lower, upper = self._attribute_bounds[attribute]
             l_val, u_val = lower(self), upper(self)
             assert l_val <= u_val
             value = max(l_val, value)
             value = min(u_val, value)
-            self._attributes[attribute] = value
+        return value
 
     def increment_attribute(self, attribute: AttributeType, delta: int) -> None:
-        self._attributes[attribute] += delta
-        self._set_attribute_in_bounds(attribute)
+        new_val = self._attributes[attribute] + delta
+        new_val = self._value_in_bounds(new_val, attribute)
+        self._attributes[attribute] = new_val
 
     def set_attribute(self, attribute: AttributeType, value: int) -> None:
+        value = self._value_in_bounds(value, attribute)
         self._attributes[attribute] = value
-        self._set_attribute_in_bounds(attribute)
+
+

--- a/src/models/states_test.py
+++ b/src/models/states_test.py
@@ -1,8 +1,27 @@
 """Tests for states.py"""
 
-from models.states import Attribute, State
+from models.states import Attribute, State, BasicStatus
 
 
 def test_str_methods():
     assert str(State.ON_FIRE) == 'on fire'
     assert str(Attribute.HEALTH) == 'health'
+
+
+def test_basic_status_attribute_bounds():
+    status = BasicStatus()
+    health_min = -5
+    health_max = 10
+    status.set_attribute(Attribute.MAX_HEALTH, health_max)
+    status.set_attribute_bounds(Attribute.HEALTH, health_min,
+                                Attribute.MAX_HEALTH)
+
+    assert status.get_attribute(Attribute.HEALTH) == 0
+    status.set_attribute(Attribute.HEALTH, health_max + 100)
+    assert status.get_attribute(Attribute.HEALTH) == health_max
+    status.increment_attribute(Attribute.HEALTH, 100)
+    assert status.get_attribute(Attribute.HEALTH) == health_max
+    status.increment_attribute(Attribute.HEALTH, -health_max + health_min - 5)
+    assert status.get_attribute(Attribute.HEALTH) == health_min
+    status.set_attribute(Attribute.HEALTH, health_min - 10)
+    assert status.get_attribute(Attribute.HEALTH) == health_min


### PR DESCRIPTION
I extracted an interface from Stateful that requires "has_state, get_attribute, and increment_attribute". The original Stateful class became BasicStatus(Stateful). The Character class now implements only the Stateful contract by using a BasicStatus object and combining its information with information in the character inventory. This should address #36 