### PR TITLE
Simplify chassis building.

### DIFF
--- a/src/characters/abilities_test.py
+++ b/src/characters/abilities_test.py
@@ -3,13 +3,14 @@ import pytest
 from characters.ability_examples import FireLaser, Repair
 from characters.character_impl import CharacterImpl
 from characters.chassis_examples import ChassisTypes
+from characters.chassis_factory import build_chassis
 from characters.conditions import FullHealth
 from characters.states import Attribute
 
 
 @pytest.fixture()
 def character():
-    return CharacterImpl(ChassisTypes.WALLE.build())
+    return CharacterImpl(build_chassis(ChassisTypes.WALLE))
 
 
 def test_repair_ability(character):
@@ -24,7 +25,7 @@ def test_repair_ability(character):
 def test_fire_laser(character):
     damage = 3
     fire_laser = FireLaser(damage)
-    other_char = CharacterImpl(ChassisTypes.DRONE.build())
+    other_char = CharacterImpl(build_chassis(ChassisTypes.DRONE))
 
     assert not fire_laser.can_use(character, character)
     assert fire_laser.can_use(character, other_char)

--- a/src/characters/character_examples.py
+++ b/src/characters/character_examples.py
@@ -2,7 +2,7 @@
 from enum import Enum
 from typing import NamedTuple
 
-from characters.chassis_examples import ChassisTypes, ChassisData
+from characters.chassis_examples import ChassisData, ChassisTypes
 from combat.ai.ai_factory import AIType
 
 CharacterData = NamedTuple(
@@ -18,7 +18,7 @@ CharacterData.__new__.__defaults__ = (  # type: ignore
 _DRONE = CharacterData('drone', ChassisTypes.DRONE.data)  # type: ignore
 _HARMLESS = CharacterData('harmless enemy',  # type: ignore
                           ChassisTypes.HARMLESS.data)
-_USELESS = CharacterData('useless enemy', # type: ignore
+_USELESS = CharacterData('useless enemy',  # type: ignore
                          ChassisTypes.USELESS.data)
 _HUMAN_PLAYER = CharacterData('Player 1', ChassisTypes.WALLE.data,
                               'src/images/walle.png', AIType.Human)

--- a/src/characters/character_examples.py
+++ b/src/characters/character_examples.py
@@ -2,12 +2,12 @@
 from enum import Enum
 from typing import NamedTuple
 
-from characters.chassis_examples import ChassisTypes
+from characters.chassis_examples import ChassisTypes, ChassisData
 from combat.ai.ai_factory import AIType
 
 CharacterData = NamedTuple(
     'EnemyData', [('name', str),
-                  ('chassis_type', ChassisTypes),
+                  ('chassis_data', ChassisData),
                   ('image_path', str),
                   ('ai_type', AIType)])
 
@@ -15,11 +15,12 @@ CharacterData = NamedTuple(
 CharacterData.__new__.__defaults__ = (  # type: ignore
     'src/images/drone.png', AIType.Random)
 
-_DRONE = CharacterData('drone', ChassisTypes.DRONE)  # type: ignore
+_DRONE = CharacterData('drone', ChassisTypes.DRONE.data)  # type: ignore
 _HARMLESS = CharacterData('harmless enemy',  # type: ignore
-                          ChassisTypes.HARMLESS)
-_USELESS = CharacterData('useless enemy', ChassisTypes.USELESS)  # type: ignore
-_HUMAN_PLAYER = CharacterData('Player 1', ChassisTypes.WALLE,
+                          ChassisTypes.HARMLESS.data)
+_USELESS = CharacterData('useless enemy', # type: ignore
+                         ChassisTypes.USELESS.data)
+_HUMAN_PLAYER = CharacterData('Player 1', ChassisTypes.WALLE.data,
                               'src/images/walle.png', AIType.Human)
 
 

--- a/src/characters/character_factory.py
+++ b/src/characters/character_factory.py
@@ -14,7 +14,7 @@ def build_character(
     else:
         data = character
 
-    chassis = build_chassis(data.chassis_type)
+    chassis = build_chassis(data.chassis_data)
     char = CharacterImpl(chassis, image_path=data.image_path,
                          name=data.name)
 

--- a/src/characters/character_factory.py
+++ b/src/characters/character_factory.py
@@ -3,6 +3,7 @@ from typing import Union
 from characters.character_examples import CharacterData, CharacterTypes
 from characters.character_impl import CharacterImpl
 from characters.character_position import Position
+from characters.chassis_factory import build_chassis
 from combat.ai.ai_factory import AIType, build_ai
 
 
@@ -13,7 +14,7 @@ def build_character(
     else:
         data = character
 
-    chassis = data.chassis_type.build()
+    chassis = build_chassis(data.chassis_type)
     char = CharacterImpl(chassis, image_path=data.image_path,
                          name=data.name)
 

--- a/src/characters/character_impl.py
+++ b/src/characters/character_impl.py
@@ -8,6 +8,7 @@ from characters.character_base import Character
 from characters.character_position import Position
 from characters.chassis import Chassis
 from characters.chassis_examples import ChassisTypes
+from characters.chassis_factory import build_chassis
 from characters.inventory import InventoryBase
 from characters.mods_base import Mod
 from characters.states import Attribute, AttributeType, BasicStatus, State
@@ -21,7 +22,7 @@ class CharacterImpl(Character):
     def __init__(self, chassis: Chassis = None, image_path: str = None,
                  name: str = 'unnamed Character') -> None:
         super().__init__()
-        chassis = ChassisTypes.WALLE.build() if chassis is None else chassis
+        chassis = build_chassis(ChassisTypes.WALLE) if chassis is None else chassis
         self._name = name
         self._inventory: InventoryBase = chassis
         self._base_status = BasicStatus()

--- a/src/characters/chassis_examples.py
+++ b/src/characters/chassis_examples.py
@@ -3,26 +3,8 @@ from typing import Dict, NamedTuple, Optional, Tuple
 
 from characters.abilities_base import Ability
 from characters.ability_examples import FireLaser, Harmless, Repair, Useless
-from characters.chassis import Chassis, Slots
-from characters.mods_base import GenericMod
+from characters.chassis import Slots
 from characters.states import Attribute, AttributeType, Skill, State
-
-
-class ChassisTypes(Enum):
-    WALLE = 'WallE'
-    DRONE = 'drone'
-    HARMLESS = 'HARMLESS'
-    USELESS = 'USELESS'
-
-    def build(self) -> Chassis:
-        data = _chassis_type_to_data[self]
-        base_mod = GenericMod(data.states_granted, data.attributes_modifiers,
-                              data.abilities_granted)
-        return Chassis(data.slot_capacities, base_mod)
-
-    def __str__(self) -> str:
-        return '{} chassis'.format(self.value)
-
 
 ChassisData = NamedTuple(
     'ChassisData',
@@ -59,6 +41,21 @@ _USELESS = ChassisData(  # type:ignore
     attributes_modifiers={Attribute.MAX_HEALTH: 1},
     abilities_granted=(Useless(1), Useless(2))
 )
+
+
+class ChassisTypes(Enum):
+    WALLE = 'WallE'
+    DRONE = 'drone'
+    HARMLESS = 'HARMLESS'
+    USELESS = 'USELESS'
+
+    @property
+    def data(self) -> ChassisData:
+        return _chassis_type_to_data[self]
+
+    def __str__(self) -> str:
+        return '{} chassis'.format(self.value)
+
 
 _chassis_type_to_data: Dict[ChassisTypes, ChassisData] = {
     ChassisTypes.WALLE: _WALLE,

--- a/src/characters/chassis_factory.py
+++ b/src/characters/chassis_factory.py
@@ -1,0 +1,15 @@
+from typing import Union
+
+from characters.chassis import Chassis
+from characters.chassis_examples import ChassisData, ChassisTypes
+from characters.mods_base import GenericMod
+
+
+def build_chassis(chassis: Union[ChassisTypes, ChassisData]) -> Chassis:
+    if isinstance(chassis, ChassisTypes):
+        data = chassis.data
+    else:
+        data = chassis
+    base_mod = GenericMod(data.states_granted, data.attributes_modifiers,
+                          data.abilities_granted)
+    return Chassis(data.slot_capacities, base_mod)


### PR DESCRIPTION
Before the ChassisTypes Enum was used to build a Chassis. Now there is a separate function that just builds a Chassis from data. The CharacterData now has chassis_data instead of chassis_type.