### PR TITLE
Fix character and chassis constructor annotation, clean up data types.

### DIFF
--- a/src/characters/abilities_base.py
+++ b/src/characters/abilities_base.py
@@ -48,6 +48,3 @@ class Ability(metaclass=abc.ABCMeta):
         if not isinstance(other, self.__class__):
             return self.__class__.__name__ < other.__class__.__name__
         return self._attrs < other._attrs  # type: ignore
-
-    def __hash__(self) -> int:
-        return hash((self.__class__.__name__,) + self._attrs)  # type: ignore

--- a/src/characters/abilities_test.py
+++ b/src/characters/abilities_test.py
@@ -10,7 +10,7 @@ from characters.states import Attribute
 
 @pytest.fixture()
 def character():
-    return build_character(CharacterData(ChassisTypes.WALLE))
+    return build_character(CharacterData(ChassisTypes.WALLE.data))
 
 
 def test_repair_ability(character):
@@ -25,7 +25,7 @@ def test_repair_ability(character):
 def test_fire_laser(character):
     damage = 3
     fire_laser = FireLaser(damage)
-    other_char = build_character(CharacterData(ChassisTypes.WALLE))
+    other_char = build_character(CharacterData(ChassisTypes.WALLE.data))
 
     assert not fire_laser.can_use(character, character)
     assert fire_laser.can_use(character, other_char)

--- a/src/characters/character_base_test.py
+++ b/src/characters/character_base_test.py
@@ -14,7 +14,7 @@ class CharacterTest(TestCase):
 
     def _character(self):
         chassis = ChassisData({TEMP_DEFAULT_SLOT: 10},
-                              attributes_modifiers={Attribute.MAX_HEALTH: 10})
+                              attribute_modifiers={Attribute.MAX_HEALTH: 10})
         return build_character(CharacterData(chassis))
 
     def test_character_has_attributes(self):

--- a/src/characters/character_examples.py
+++ b/src/characters/character_examples.py
@@ -7,22 +7,18 @@ from characters.mod_examples import ModTypes
 from characters.mods_base import ModData
 from combat.ai_factory import AIType
 
-CharacterData = NamedTuple(
-    'EnemyData', [('chassis_data', ChassisData),
-                  ('name', str),
-                  ('mods', Tuple[ModData, ...]),
-                  ('image_path', str),
-                  ('ai_type', AIType)])
 
-# Sets default values.
-CharacterData.__new__.__defaults__ = ('', (),  # type: ignore
-                                      'src/images/drone.png', AIType.Random)
+class CharacterData(NamedTuple):
+    chassis_data: ChassisData
+    name: str = 'unnamed Character'
+    mods: Tuple[ModData, ...] = ()
+    image_path: str = 'src/images/drone.png'
+    ai_type: AIType = AIType.Random
 
-_DRONE = CharacterData(ChassisTypes.DRONE.data, 'drone')  # type: ignore
-_HARMLESS = CharacterData(ChassisTypes.HARMLESS.data,  # type: ignore
-                          'harmless enemy')
-_USELESS = CharacterData(ChassisTypes.USELESS.data,  # type: ignore
-                         'useless enemy')
+
+_DRONE = CharacterData(ChassisTypes.DRONE.data, 'drone')
+_HARMLESS = CharacterData(ChassisTypes.HARMLESS.data, 'harmless enemy')
+_USELESS = CharacterData(ChassisTypes.USELESS.data, 'useless enemy')
 
 _HUMAN_PLAYER = CharacterData(ChassisTypes.WALLE.data, 'Player 1',
                               (ModTypes.SMALL_LASER.data,

--- a/src/characters/character_factory.py
+++ b/src/characters/character_factory.py
@@ -9,13 +9,7 @@ from characters.states import Attribute
 from combat.ai_factory import AIType, build_ai
 
 
-def build_character(
-        character: Union[CharacterTypes, CharacterData]) -> CharacterImpl:
-    if isinstance(character, CharacterTypes):
-        data = character.data
-    else:
-        data = character
-
+def build_character(data: CharacterData) -> CharacterImpl:
     chassis = build_chassis(data.chassis_data)
     char = CharacterImpl(chassis, image_path=data.image_path, name=data.name)
 

--- a/src/characters/character_factory.py
+++ b/src/characters/character_factory.py
@@ -1,6 +1,6 @@
 from typing import Union
 
-from characters.character_examples import CharacterData, CharacterTypes
+from characters.character_examples import CharacterData
 from characters.character_impl import CharacterImpl
 from characters.character_position import Position
 from characters.chassis_factory import build_chassis

--- a/src/characters/character_factory.py
+++ b/src/characters/character_factory.py
@@ -1,5 +1,3 @@
-from typing import Union
-
 from characters.character_examples import CharacterData
 from characters.character_impl import CharacterImpl
 from characters.character_position import Position

--- a/src/characters/character_impl.py
+++ b/src/characters/character_impl.py
@@ -23,7 +23,7 @@ class CharacterImpl(Character):
                  name: str = 'unnamed Character') -> None:
         super().__init__()
         if chassis is None:
-            chassis = build_chassis(ChassisTypes.WALLE)
+            chassis = build_chassis(ChassisTypes.WALLE.data)
         self._name = name
         self.inventory: InventoryBase = chassis
         self._base_status = BasicStatus()

--- a/src/characters/chassis_examples.py
+++ b/src/characters/chassis_examples.py
@@ -1,44 +1,40 @@
 from enum import Enum
-from typing import Dict, NamedTuple, Optional, Tuple
+from typing import Dict, NamedTuple, Tuple
 
 from characters.abilities_base import Ability
 from characters.ability_examples import FireLaser, Harmless, Repair, Useless
 from characters.chassis import Slots
 from characters.states import Attribute, AttributeType, Skill, State
 
-ChassisData = NamedTuple(
-    'ChassisData',
-    [('slot_capacities', Dict[Slots, int]),
-     ('states_granted', Optional[Tuple[State, ...]]),
-     ('attributes_modifiers', Optional[Dict[AttributeType, int]]),
-     ('abilities_granted', Optional[Tuple[Ability, ...]])])
 
-# This sets default values.
-# I realize that {} is mutable, but I don't want to have to install the package
-# frozendict just for this.
-ChassisData.__new__.__defaults__ = ({}, (), {}, ())  # type: ignore
+class ChassisData(NamedTuple):
+    slot_capacities: Dict[Slots, int] = {}
+    states_granted: Tuple[State, ...] = ()
+    attribute_modifiers: Dict[AttributeType, int] = {}
+    abilities_granted: Tuple[Ability, ...] = ()
 
-_WALLE = ChassisData(  # type: ignore
+
+_WALLE = ChassisData(
     slot_capacities={Slots.HEAD: 10, Slots.CHEST: 1, Slots.ARMS: 2,
                      Slots.STORAGE: 1},
-    attributes_modifiers={Attribute.MAX_HEALTH: 10, Skill.STEALTH: 1,
-                          Skill.MECHANICS: 1},
-    abilities_granted=(Repair(5)))
+    attribute_modifiers={Attribute.MAX_HEALTH: 10, Skill.STEALTH: 1,
+                         Skill.MECHANICS: 1},
+    abilities_granted=(Repair(5),))
 
-_DRONE = ChassisData(  # type: ignore
+_DRONE = ChassisData(
     slot_capacities={Slots.HEAD: 1, Slots.STORAGE: 1},
     states_granted=(State.ON_FIRE,),
-    attributes_modifiers={Attribute.MAX_HEALTH: 5},
+    attribute_modifiers={Attribute.MAX_HEALTH: 5},
     abilities_granted=(FireLaser(2),)
 )
 
-_HARMLESS = ChassisData(  # type:ignore
-    attributes_modifiers={Attribute.MAX_HEALTH: 1},
+_HARMLESS = ChassisData(
+    attribute_modifiers={Attribute.MAX_HEALTH: 1},
     abilities_granted=(Harmless(1), Harmless(2), Useless(1), Useless(2))
 )
 
-_USELESS = ChassisData(  # type:ignore
-    attributes_modifiers={Attribute.MAX_HEALTH: 1},
+_USELESS = ChassisData(
+    attribute_modifiers={Attribute.MAX_HEALTH: 1},
     abilities_granted=(Useless(1), Useless(2))
 )
 

--- a/src/characters/chassis_factory.py
+++ b/src/characters/chassis_factory.py
@@ -1,15 +1,9 @@
-from typing import Union
-
 from characters.chassis import Chassis
-from characters.chassis_examples import ChassisData, ChassisTypes
+from characters.chassis_examples import ChassisData
 from characters.mods_base import GenericMod
 
 
-def build_chassis(chassis: Union[ChassisTypes, ChassisData]) -> Chassis:
-    if isinstance(chassis, ChassisTypes):
-        data = chassis.data
-    else:
-        data = chassis
+def build_chassis(data: ChassisData) -> Chassis:
     base_mod = GenericMod(data.states_granted, data.attributes_modifiers,
                           data.abilities_granted)
     return Chassis(data.slot_capacities, base_mod)

--- a/src/characters/chassis_factory.py
+++ b/src/characters/chassis_factory.py
@@ -4,6 +4,6 @@ from characters.mods_base import GenericMod
 
 
 def build_chassis(data: ChassisData) -> Chassis:
-    base_mod = GenericMod(data.states_granted, data.attributes_modifiers,
+    base_mod = GenericMod(data.states_granted, data.attribute_modifiers,
                           data.abilities_granted)
     return Chassis(data.slot_capacities, base_mod)

--- a/src/characters/effects_test.py
+++ b/src/characters/effects_test.py
@@ -35,7 +35,7 @@ def test_increment_player_attribute(player):
 
 
 def test_increment_attribute():
-    char = build_character(CharacterTypes.DRONE)
+    char = build_character(CharacterTypes.DRONE.data)
     health = char.get_attribute(Attribute.HEALTH)
     delta = -3
     IncrementAttribute(char, Attribute.HEALTH, delta).execute()

--- a/src/characters/player.py
+++ b/src/characters/player.py
@@ -15,4 +15,4 @@ def get_player() -> Character:
 
 def reset_player() -> None:
     global _player
-    _player = build_character(CharacterTypes.HUMAN_PLAYER)
+    _player = build_character(CharacterTypes.HUMAN_PLAYER.data)

--- a/src/combat/ai_test.py
+++ b/src/combat/ai_test.py
@@ -14,9 +14,9 @@ class AITest(TestCase):
 
     @parameterized.expand(AI_TYPES)
     def test_no_valid_moves_raises(self, ai_type):
-        user = build_character(CharacterTypes.USELESS)
+        user = build_character(CharacterTypes.USELESS.data)
         ai = build_ai(user, ai_type)
-        target = build_character(CharacterTypes.USELESS)
+        target = build_character(CharacterTypes.USELESS.data)
         ai.set_targets([target])
 
         with self.assertRaises(AssertionError):

--- a/src/combat/combat_test_utils.py
+++ b/src/combat/combat_test_utils.py
@@ -25,7 +25,7 @@ def create_combat_group(group_size, health=10, damage=2, base_name='combatant'):
 
 
 def create_enemy(health: int = 10) -> Character:
-    enemy = build_character(CharacterTypes.DRONE)
+    enemy = build_character(CharacterTypes.DRONE.data)
     cur_val = enemy.get_attribute(Attribute.HEALTH)
     enemy.increment_attribute(Attribute.HEALTH, -cur_val)
     enemy.increment_attribute(Attribute.HEALTH, health)

--- a/src/combat/shuffle_ai_test.py
+++ b/src/combat/shuffle_ai_test.py
@@ -9,8 +9,8 @@ from combat.shuffle_ai import ShuffleAI
 class ShuffleAITest(TestCase):
 
     def test_shuffle_ai_only_provides_usable_moves(self):
-        user = build_character(CharacterTypes.HARMLESS)
-        target = build_character(CharacterTypes.HARMLESS)
+        user = build_character(CharacterTypes.HARMLESS.data)
+        target = build_character(CharacterTypes.HARMLESS.data)
         ai = ShuffleAI(user=user)
         ai.set_targets([target])
 
@@ -19,8 +19,8 @@ class ShuffleAITest(TestCase):
             self.assertIsInstance(move.ability, Harmless)
 
     def test_shuffle_ai_moves_dont_repeat(self):
-        user = build_character(CharacterTypes.HARMLESS)
-        target = build_character(CharacterTypes.HARMLESS)
+        user = build_character(CharacterTypes.HARMLESS.data)
+        target = build_character(CharacterTypes.HARMLESS.data)
         ai = ShuffleAI(user=user)
         ai.set_targets([target])
 
@@ -41,8 +41,8 @@ class ShuffleAITest(TestCase):
             self.assertLess(move_repeat_count, 3)
 
     def test_no_valid_moves_raises(self):
-        user = build_character(CharacterTypes.USELESS)
-        target = build_character(CharacterTypes.USELESS)
+        user = build_character(CharacterTypes.USELESS.data)
+        target = build_character(CharacterTypes.USELESS.data)
         ai = ShuffleAI(user=user)
         ai.set_targets([target])
 

--- a/src/simulation/simulation_manager_test.py
+++ b/src/simulation/simulation_manager_test.py
@@ -8,25 +8,26 @@ class TestSimulationManager(TestCase):
 
     def test_useless_enemy_always_loses(self):
         manager = SimulationManager()
-        winrate = manager.simulate(CharacterTypes.HARMLESS,
-                                   CharacterTypes.DRONE, n_runs=100)
+        winrate = manager.simulate(CharacterTypes.HARMLESS.data,
+                                   CharacterTypes.DRONE.data, n_runs=100)
         self.assertEqual(winrate, 0.0)
 
     def test_drone_always_wins(self):
         manager = SimulationManager()
-        winrate = manager.simulate(CharacterTypes.DRONE,
-                                   CharacterTypes.HARMLESS,
+        winrate = manager.simulate(CharacterTypes.DRONE.data,
+                                   CharacterTypes.HARMLESS.data,
                                    n_runs=100)
         self.assertEqual(winrate, 1.0)
 
     def test_useless_enemies_never_finish_raises(self):
         manager = SimulationManager()
         with self.assertRaises(SimulationError):
-            manager.simulate(CharacterTypes.HARMLESS,
-                             CharacterTypes.HARMLESS, n_runs=100)
+            manager.simulate(CharacterTypes.HARMLESS.data,
+                             CharacterTypes.HARMLESS.data, n_runs=100)
 
     def test_combatants_without_moves_raises(self):
         manager = SimulationManager()
         with self.assertRaises(AssertionError):
-            manager.simulate(CharacterTypes.USELESS, CharacterTypes.USELESS,
+            manager.simulate(CharacterTypes.USELESS.data,
+                             CharacterTypes.USELESS.data,
                              n_runs=100)

--- a/src/world/locations.py
+++ b/src/world/locations.py
@@ -1,5 +1,6 @@
 from characters.character_base import Character
-from characters.character_factory import CharacterTypes, build_character
+from characters.character_examples import CharacterTypes
+from characters.character_factory import build_character
 from world.location_base import Location
 
 _BACKGROUND_IMAGE_LOADING = 'src/images/background_loading.png'

--- a/src/world/locations.py
+++ b/src/world/locations.py
@@ -14,7 +14,7 @@ class LoadingLocation(Location):
 
     # TODO - this doesnt make sense here
     def random_enemy(self) -> Character:
-        return build_character(CharacterTypes.DRONE)
+        return build_character(CharacterTypes.DRONE.data)
 
 
 class MarsLocation(Location):
@@ -23,7 +23,7 @@ class MarsLocation(Location):
         super().__init__(_BACKGROUND_IMAGE_MARS)
 
     def random_enemy(self) -> Character:
-        return build_character(CharacterTypes.DRONE)
+        return build_character(CharacterTypes.DRONE.data)
 
 
 class CityLocation(Location):
@@ -32,4 +32,4 @@ class CityLocation(Location):
         super().__init__(_BACKGROUND_IMAGE_CITY)
 
     def random_enemy(self) -> Character:
-        return build_character(CharacterTypes.DRONE)
+        return build_character(CharacterTypes.DRONE.data)


### PR DESCRIPTION
Apparently there is a way to define a default value of NamedTuples that mypy can see, so I did that for CharacterData and ChassisData. Fixes #186 