### PR TITLE
Define Active slots in Inventory, Chassis

### DIFF
--- a/src/characters/character_base_test.py
+++ b/src/characters/character_base_test.py
@@ -8,11 +8,13 @@ from characters.conditions import IsDead
 from characters.mods_base import GenericMod, Slots
 from characters.states import Attribute, State
 
+_ACTIVE_SLOT = Slots.ARMS
+
 
 class CharacterTest(TestCase):
 
     def _character(self):
-        chassis = ChassisData({Slots.STORAGE: 10},
+        chassis = ChassisData({Slots.STORAGE: 10, _ACTIVE_SLOT: 10},
                               attribute_modifiers={Attribute.MAX_HEALTH: 10})
         return build_character(CharacterData(chassis))
 
@@ -30,7 +32,8 @@ class CharacterTest(TestCase):
         char = self._character()
 
         assert not char.has_state(State.ON_FIRE)
-        char.attempt_pickup(GenericMod(states_granted=State.ON_FIRE))
+        char.attempt_pickup(
+            GenericMod(states_granted=State.ON_FIRE, valid_slots=_ACTIVE_SLOT))
         assert char.has_state(State.ON_FIRE)
 
     def test_mods_affect_max_attribute(self):
@@ -38,7 +41,8 @@ class CharacterTest(TestCase):
         max_health = char.get_attribute(Attribute.MAX_HEALTH)
         bonus = 5
         char.attempt_pickup(
-            GenericMod(attribute_modifiers={Attribute.MAX_HEALTH: bonus}))
+            GenericMod(attribute_modifiers={Attribute.MAX_HEALTH: bonus},
+                       valid_slots=_ACTIVE_SLOT))
 
         assert char.get_attribute(Attribute.MAX_HEALTH) == max_health + bonus
 
@@ -57,5 +61,6 @@ class CharacterTest(TestCase):
         ability = FireLaser(12)
         assert ability not in char.abilities()
 
-        char.attempt_pickup(GenericMod(abilities_granted=ability))
+        char.attempt_pickup(
+            GenericMod(abilities_granted=ability, valid_slots=_ACTIVE_SLOT))
         assert ability in char.abilities()

--- a/src/characters/character_base_test.py
+++ b/src/characters/character_base_test.py
@@ -5,14 +5,14 @@ from characters.character_examples import CharacterData
 from characters.character_factory import build_character
 from characters.chassis_examples import ChassisData
 from characters.conditions import IsDead
-from characters.mods_base import TEMP_DEFAULT_SLOT, GenericMod
+from characters.mods_base import GenericMod, Slots
 from characters.states import Attribute, State
 
 
 class CharacterTest(TestCase):
 
     def _character(self):
-        chassis = ChassisData({TEMP_DEFAULT_SLOT: 10},
+        chassis = ChassisData({Slots.STORAGE: 10},
                               attribute_modifiers={Attribute.MAX_HEALTH: 10})
         return build_character(CharacterData(chassis))
 

--- a/src/characters/character_base_test.py
+++ b/src/characters/character_base_test.py
@@ -62,5 +62,5 @@ class CharacterTest(TestCase):
         assert ability not in char.abilities()
 
         char.attempt_pickup(
-            GenericMod(abilities_granted=ability, valid_slots=_ACTIVE_SLOT1111))
+            GenericMod(abilities_granted=ability, valid_slots=_ACTIVE_SLOT))
         assert ability in char.abilities()

--- a/src/characters/character_base_test.py
+++ b/src/characters/character_base_test.py
@@ -62,5 +62,5 @@ class CharacterTest(TestCase):
         assert ability not in char.abilities()
 
         char.attempt_pickup(
-            GenericMod(abilities_granted=ability, valid_slots=_ACTIVE_SLOT))
+            GenericMod(abilities_granted=ability, valid_slots=_ACTIVE_SLOT1111))
         assert ability in char.abilities()

--- a/src/characters/chassis.py
+++ b/src/characters/chassis.py
@@ -21,39 +21,49 @@ class Chassis(InventoryBase):
         self._slot_capacities: Dict[Slots, int] = slot_capacities.copy()
         self._slot_capacities.update({slot: 0 for slot in Slots
                                       if slot not in slot_capacities})
-        self._slots: Dict[Slots, List[Mod]] = {slot: [] for slot in Slots}
+        self._stored_mods: Dict[Slots, List[Mod]] = {slot: [] for slot in Slots}
         self._base_mod = base_mod
 
     def can_store(self, mod: Mod) -> bool:
         available_slots = self._open_slots(mod.valid_slots())
         if not available_slots:
             return False
-        return all(mod not in self._slots[slot] for slot in available_slots)
+        return all(
+            mod not in self._stored_mods[slot] for slot in available_slots)
 
     def _open_slots(self, slots: Iterable[Slots]) -> List[Slots]:
         return [s for s in slots if self._slot_vacant(s)]
 
     def _slot_vacant(self, slot: Slots) -> bool:
-        return len(self._slots[slot]) < self._slot_capacities[slot]
+        return len(self._stored_mods[slot]) < self._slot_capacities[slot]
 
     def _store(self, mod: Mod) -> None:
         slot = self._open_slots(mod.valid_slots())[0]
-        self._slots[slot].append(mod)
+        self._stored_mods[slot].append(mod)
         logging.debug('INVENTORY: Storing mod in slot {}.'.format(slot.value))
 
     def remove_mod(self, mod: Mod) -> None:
 
         for slot in mod.valid_slots():
-            if mod in self._slots[slot]:
-                self._slots[slot].remove(mod)
+            if mod in self._stored_mods[slot]:
+                self._stored_mods[slot].remove(mod)
                 logging.debug(
                     'INVENTORY: Mod removed from slot {}'.format(slot.value))
 
     def all_mods(self) -> Iterable[Mod]:
+        return self._all_mods(active_only=False)
+
+    def _all_mods(self, active_only: bool = True) -> Iterable[Mod]:
         # noinspection PyTypeChecker
+        checked_slots = set(self._stored_mods.keys())
+        if active_only:
+            checked_slots.remove(Slots.STORAGE)
         mods = reduce(set.union,  # type: ignore
-                      (set(slot) for slot in
-                       self._slots.values()))  # type: ignore
+                      (set(self._stored_mods[slot])
+                       for slot in checked_slots))  # type: ignore
         if self._base_mod is not None:
             mods.add(self._base_mod)
         return mods
+
+    def all_active_mods(self) -> Iterable[Mod]:
+        return self._all_mods(active_only=True)

--- a/src/characters/chassis.py
+++ b/src/characters/chassis.py
@@ -38,7 +38,13 @@ class Chassis(InventoryBase):
         return len(self._stored_mods[slot]) < self._slot_capacities[slot]
 
     def _store(self, mod: Mod) -> None:
-        slot = self._open_slots(mod.valid_slots())[0]
+        slots_available = self._open_slots(mod.valid_slots())
+        active_slots_available = set(slots_available) - {Slots.STORAGE}
+        if active_slots_available:
+            slot = active_slots_available.pop()
+        else:
+            slot = Slots.STORAGE
+
         self._stored_mods[slot].append(mod)
         logging.debug('INVENTORY: Storing mod in slot {}.'.format(slot.value))
 

--- a/src/characters/chassis_test.py
+++ b/src/characters/chassis_test.py
@@ -41,3 +41,26 @@ def test_chassis_base_mod_included():
     chassis = Chassis({}, base_mod=base_mod)
 
     assert len(list(chassis.all_mods())) == 1
+
+
+def test_chassis_stores_in_active_slot_first():
+    chassis = Chassis({Slots.ARMS: 1, Slots.STORAGE: 1})
+
+    fire_mod = GenericMod(states_granted=State.ON_FIRE, valid_slots=Slots.ARMS)
+    chassis.store(fire_mod)
+    assert chassis.grants_state(State.ON_FIRE)
+    assert fire_mod in chassis.all_active_mods()
+
+
+def test_chassis_mods_in_storage_not_active():
+    chassis = Chassis({Slots.ARMS: 1, Slots.STORAGE: 1})
+    mod = GenericMod(valid_slots=Slots.CHEST)
+    chassis.store(mod)
+    assert mod not in chassis.all_active_mods()
+    assert mod in chassis.all_mods()
+
+
+def test_chassis_base_mod_is_active():
+    mod = GenericMod()
+    chassis = Chassis({}, base_mod=mod)
+    assert mod in chassis.all_active_mods()

--- a/src/characters/chassis_test.py
+++ b/src/characters/chassis_test.py
@@ -1,7 +1,10 @@
 """Tests for the Chassis class"""
+from characters.ability_examples import FireLaser
+from characters.chassis import Chassis
 from characters.chassis_examples import ChassisData
 from characters.chassis_factory import build_chassis
 from characters.mods_base import GenericMod, Slots
+from characters.states import State, Attribute
 
 
 def test_chassis_can_store_in_storage_by_default():
@@ -21,3 +24,20 @@ def test_chassis_can_store_after_making_space():
     chassis.remove_mod(mod)
     assert chassis.can_store(second_mod)
     chassis.remove_mod(second_mod)
+
+
+def test_chassis_cannot_store_same_mod_twice():
+    chassis = Chassis({Slots.STORAGE: 2})
+    mod = GenericMod()
+
+    chassis.store(mod)
+    assert not chassis.can_store(mod)
+
+
+def test_chassis_base_mod_included():
+    base_mod = GenericMod(states_granted=State.ON_FIRE,
+                          attribute_modifiers={Attribute.CREDITS: 3},
+                          abilities_granted=FireLaser(3))
+    chassis = Chassis({}, base_mod=base_mod)
+
+    assert len(list(chassis.all_mods())) == 1

--- a/src/characters/chassis_test.py
+++ b/src/characters/chassis_test.py
@@ -4,7 +4,7 @@ from characters.chassis import Chassis
 from characters.chassis_examples import ChassisData
 from characters.chassis_factory import build_chassis
 from characters.mods_base import GenericMod, Slots
-from characters.states import State, Attribute
+from characters.states import Attribute, State
 
 
 def test_chassis_can_store_in_storage_by_default():

--- a/src/characters/inventory.py
+++ b/src/characters/inventory.py
@@ -34,10 +34,17 @@ class InventoryBase(metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     def all_mods(self) -> Iterable[Mod]:
-        """Iterate over all mods in storage."""
+        """Iterate over all mods, including inactive mods."""
 
-    def mods(self, check: Callable[[Mod], bool]) -> Iterable[Mod]:
+    @abc.abstractmethod
+    def all_active_mods(self) -> Iterable[Mod]:
+        """Iterate over all active mods."""
+
+    def mods(self, check: Callable[[Mod], bool],
+             active_only: bool = True) -> Iterable[Mod]:
         """All mods satisfying a given boolean function."""
+        if active_only:
+            return (m for m in self.all_active_mods() if check(m))
         return (m for m in self.all_mods() if check(m))
 
     def grants_state(self, state: State) -> bool:
@@ -76,3 +83,5 @@ class BasicInventory(InventoryBase):
 
     def all_mods(self) -> Iterable[Mod]:
         return (m for m in self._mods)
+
+    all_active_mods = all_mods

--- a/src/characters/inventory_test.py
+++ b/src/characters/inventory_test.py
@@ -23,23 +23,6 @@ def test_inventory_storage_sizes(make_inventory):
     assert len(list(inventory.all_mods())) == 2
 
 
-def test_chassis_cannot_store_same_mod_twice():
-    chassis = Chassis({Slots.STORAGE: 2})
-    mod = GenericMod()
-
-    chassis.store(mod)
-    assert not chassis.can_store(mod)
-
-
-def test_chassis_base_mod_included():
-    base_mod = GenericMod(states_granted=State.ON_FIRE,
-                          attribute_modifiers={Attribute.CREDITS: 3},
-                          abilities_granted=FireLaser(3))
-    chassis = Chassis({}, base_mod=base_mod)
-
-    assert len(list(chassis.all_mods())) == 1
-
-
 @pytest.mark.parametrize('make_inventory', factories)
 def test_basic_inventory_removal(make_inventory):
     mod = GenericMod()

--- a/src/characters/inventory_test.py
+++ b/src/characters/inventory_test.py
@@ -46,13 +46,16 @@ def test_basic_inventory_mods(make_inventory):
     inventory.store(GenericMod(attribute_modifiers={Attribute.MAX_HEALTH: 3},
                                abilities_granted=Repair(3)))
 
-    mods = list(inventory.mods(lambda x: bool(x.abilities_granted())))
+    mods = list(inventory.mods(lambda x: bool(x.abilities_granted()),
+                               active_only=False))
     assert len(mods) == 2
 
-    mods = list(inventory.mods(lambda x: bool(x.states_granted())))
+    mods = list(
+        inventory.mods(lambda x: bool(x.states_granted()), active_only=False))
     assert len(mods) == 1
 
-    mods = list(inventory.mods(lambda x: bool(x.attribute_modifiers())))
+    mods = list(inventory.mods(lambda x: bool(x.attribute_modifiers()),
+                               active_only=False))
     assert len(mods) == 3
 
 

--- a/src/characters/inventory_test.py
+++ b/src/characters/inventory_test.py
@@ -5,10 +5,10 @@ import pytest
 from characters.ability_examples import FireLaser, Repair
 from characters.chassis import Chassis
 from characters.inventory import BasicInventory
-from characters.mods_base import TEMP_DEFAULT_SLOT, GenericMod
+from characters.mods_base import GenericMod, Slots
 from characters.states import Attribute, State
 
-factories = (BasicInventory, partial(Chassis, {TEMP_DEFAULT_SLOT: 4}))
+factories = (BasicInventory, partial(Chassis, {Slots.STORAGE: 4}))
 
 
 @pytest.mark.parametrize('make_inventory', factories)
@@ -24,19 +24,11 @@ def test_inventory_storage_sizes(make_inventory):
 
 
 def test_chassis_cannot_store_same_mod_twice():
-    chassis = Chassis({TEMP_DEFAULT_SLOT: 2})
+    chassis = Chassis({Slots.STORAGE: 2})
     mod = GenericMod()
 
     chassis.store(mod)
     assert not chassis.can_store(mod)
-
-
-def test_chassis_cannot_store_when_full():
-    chassis = Chassis({TEMP_DEFAULT_SLOT: 2})
-
-    chassis.store(GenericMod())
-    chassis.store(GenericMod())
-    assert not chassis.can_store(GenericMod())
 
 
 def test_chassis_base_mod_included():

--- a/src/characters/mods_base.py
+++ b/src/characters/mods_base.py
@@ -15,9 +15,6 @@ class Slots(Enum):
     STORAGE = 'storage'
 
 
-TEMP_DEFAULT_SLOT = Slots.STORAGE
-
-
 class Mod(metaclass=abc.ABCMeta):
     """Grants state(s) or modifies character attributes."""
 

--- a/src/combat/combat_manager_base_test.py
+++ b/src/combat/combat_manager_base_test.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 
 from characters.ability_examples import FireLaser, Repair
-from characters.mods_base import GenericMod
+from characters.mods_base import GenericMod, Slots
 from characters.states import Attribute
 from combat.combat_manager_base import CombatManager
 from combat.combat_test_utils import create_combat_group
@@ -44,7 +44,8 @@ class CombatManagerTest(TestCase):
     def test_enumerates_attack_and_defense(self):
         attacker = create_combat_group(1, base_name='attacker')
         defender = create_combat_group(1, base_name='defender')
-        defender[0].attempt_pickup(GenericMod(abilities_granted=(Repair(5))))
+        defender[0].attempt_pickup(
+            GenericMod(abilities_granted=(Repair(5)), valid_slots=Slots.ARMS))
         defender[0].increment_attribute(Attribute.HEALTH, -5)
         manager = CombatManager(attackers=attacker, defenders=defender)
 
@@ -71,7 +72,8 @@ class CombatManagerTest(TestCase):
         self.assertEqual(len(defense_moves[1]), 1)
 
         # each defense move is just the laser ability
-        for expected_move, defender_moveset in zip([FireLaser, Repair], defense_moves):
+        for expected_move, defender_moveset in zip([FireLaser, Repair],
+                                                   defense_moves):
             for move in defender_moveset:
                 self.assertIsInstance(move.ability, expected_move)
 
@@ -80,7 +82,8 @@ class CombatManagerTest(TestCase):
         damage = 2
         ndefenders = 2
         attacker = create_combat_group(1, health=health, damage=damage)
-        two_defenders = create_combat_group(ndefenders, health=health, damage=damage)
+        two_defenders = create_combat_group(ndefenders, health=health,
+                                            damage=damage)
         manager = CombatManager(attackers=attacker, defenders=two_defenders)
 
         defense_moves = manager.defenders_moves
@@ -92,8 +95,10 @@ class CombatManagerTest(TestCase):
         self.assertEqual(attacker_health, health - ndefenders * damage)
 
         # attacker only hits one defender
-        first_defender_health = attack_moves[0][0].target.get_attribute(Attribute.HEALTH)
-        second_defender_health = attack_moves[1][0].target.get_attribute(Attribute.HEALTH)
+        first_defender_health = attack_moves[0][0].target.get_attribute(
+            Attribute.HEALTH)
+        second_defender_health = attack_moves[1][0].target.get_attribute(
+            Attribute.HEALTH)
         self.assertEqual(first_defender_health, health - damage)
         self.assertEqual(second_defender_health, health)
 
@@ -102,7 +107,8 @@ class CombatManagerTest(TestCase):
         damage = 2
         ndefenders = 2
         attacker = create_combat_group(1, health=health, damage=damage)
-        two_defenders = create_combat_group(ndefenders, health=health, damage=damage)
+        two_defenders = create_combat_group(ndefenders, health=health,
+                                            damage=damage)
         manager = CombatManager(attackers=attacker, defenders=two_defenders)
 
         defense_moves = manager.defenders_moves
@@ -126,7 +132,8 @@ class CombatManagerTest(TestCase):
         damage = 2
         ndefenders = 2
         attacker = create_combat_group(1, health=health, damage=damage)
-        two_defenders = create_combat_group(ndefenders, health=health, damage=damage)
+        two_defenders = create_combat_group(ndefenders, health=health,
+                                            damage=damage)
         manager = CombatManager(attackers=attacker, defenders=two_defenders)
 
         defense_moves = manager.defenders_moves

--- a/src/combat/combat_test_utils.py
+++ b/src/combat/combat_test_utils.py
@@ -3,7 +3,7 @@ from characters.character_examples import CharacterData, CharacterTypes
 from characters.character_factory import build_character
 from characters.chassis_examples import ChassisData
 from characters.mod_examples import FireLaser
-from characters.mods_base import TEMP_DEFAULT_SLOT, ModData, Slots
+from characters.mods_base import ModData, Slots
 from characters.states import Attribute
 from combat.ai_factory import AIType
 

--- a/src/combat/combat_test_utils.py
+++ b/src/combat/combat_test_utils.py
@@ -3,15 +3,15 @@ from characters.character_examples import CharacterData, CharacterTypes
 from characters.character_factory import build_character
 from characters.chassis_examples import ChassisData
 from characters.mod_examples import FireLaser
-from characters.mods_base import TEMP_DEFAULT_SLOT, ModData
+from characters.mods_base import TEMP_DEFAULT_SLOT, ModData, Slots
 from characters.states import Attribute
 from combat.ai_factory import AIType
 
 
 def get_combatant(health, abilities, name, ai_type=AIType.Human) -> Character:
     mod_data = ModData(attribute_modifiers={Attribute.MAX_HEALTH: health},
-                       abilities_granted=abilities)
-    chassis_data = ChassisData({TEMP_DEFAULT_SLOT: 10})
+                       abilities_granted=abilities, valid_slots=(Slots.ARMS,))
+    chassis_data = ChassisData({Slots.ARMS: 10})
     char_data = CharacterData(chassis_data, name, (mod_data,), '', ai_type)
 
     return build_character(char_data)


### PR DESCRIPTION
Only mods stored in active (i.e., not storage) slots grant abilities, states, etc. Chassis stores preferentially in active slots over storage, if possible.