### PR TITLE
Inventory scene now takes a function for ground mods

### DIFF
--- a/src/events/integration_test.py
+++ b/src/events/integration_test.py
@@ -207,7 +207,7 @@ def test_inventory_scene_control_flow():
     ground_mods = _typical_mods(mod_locs)
 
     def start_scene() -> DecisionScene:
-        loot_scene = partial(InventoryScene, start_scene, ground_mods)
+        loot_scene = partial(InventoryScene, start_scene, lambda: ground_mods)
         return DecisionScene('dummy scene for testing purposes',
                              {'1': DecisionOption('Loot', loot_scene)})
 

--- a/src/models/scenes/inventory_scene.py
+++ b/src/models/scenes/inventory_scene.py
@@ -37,13 +37,24 @@ class SelectedModInfo(NamedTuple):
 class InventoryScene(Scene, EventListener):
 
     def __init__(self, prev_scene_loader: Callable[[], Scene],
-                 loot_mods: Iterable[Mod] = ()) -> None:
+                 loot_mods: Callable[[], Iterable[Mod]] = None) -> None:
+        """
+
+        Args:
+            prev_scene_loader: Zero-argument function that returns the previous
+                scene.
+            loot_mods: Zero-argument function that returns the mods on the
+                ground.
+        """
         super().__init__()
         self._background_image = BackgroundImages.INVENTORY.path
         self._player = get_player()
         self._layout: Layout = None
         self._selected_mod: Mod = None
-        self._mods_on_ground = list(loot_mods)
+        if loot_mods is not None:
+            self._mods_on_ground = list(loot_mods())
+        else:
+            self._mods_on_ground = []
         self._update_layout()
         self._resolution = BasicResolution(prev_scene_loader)
         self._is_resolved = False

--- a/src/models/scenes/scene_examples.py
+++ b/src/models/scenes/scene_examples.py
@@ -1,11 +1,11 @@
 """Simple decision scene examples."""
 from enum import Enum
 from functools import partial
-from typing import Dict, cast
+from typing import Dict, Tuple, cast
 
 from data.constants import BackgroundImages
 from models.characters.effects import IncrementAttribute, RestartGame
-from models.characters.mods_base import GenericMod, SlotTypes
+from models.characters.mods_base import GenericMod, Mod, SlotTypes
 from models.characters.player import get_player
 from models.characters.states import Attributes, Skill
 from models.characters.subroutine_examples import direct_damage
@@ -37,9 +37,10 @@ def start_scene() -> DecisionScene:
     return DecisionScene(main_text, options)
 
 
-_mini_laser_mod = GenericMod(
-    subroutines_granted=direct_damage(1, 0, 1, 'Mini laser'),
-    valid_slots=SlotTypes.HEAD, description='Mini laser')
+def _mini_laser() -> Tuple[Mod]:
+    return GenericMod(
+        subroutines_granted=direct_damage(1, 0, 1, 'Mini laser'),
+        valid_slots=SlotTypes.HEAD, description='Mini laser'),
 
 
 @from_transition('This transition was defined using a decorator.')
@@ -51,7 +52,7 @@ def swamp_scene() -> DecisionScene:
                  'hibernation mode.')
 
     def success() -> Scene:
-        load_loot_scene = partial(InventoryScene, success, (_mini_laser_mod,))
+        load_loot_scene = partial(InventoryScene, success, _mini_laser)
         gain_3 = IncrementAttribute(Attributes.CREDITS, 3)
         return DecisionScene(
             'After deactivating the drone, you pick up 3 credits and '
@@ -92,7 +93,7 @@ def example_combat_scene() -> 'combat_scene.CombatScene':
     restart = transition_to(start_scene, 'Back to beginning!')
 
     loot_scene = partial(InventoryScene, prev_scene_loader=restart,
-                         loot_mods=(_mini_laser_mod,))
+                         loot_mods=_mini_laser)
     victory = BasicResolution(transition_to(loot_scene,
                                             'Victory! You loot the body.'))
 


### PR DESCRIPTION
This prevents the same mod from being picked up twice, which can cause errors.